### PR TITLE
Pass entire file into fileTemplate

### DIFF
--- a/src/FileView.js
+++ b/src/FileView.js
@@ -21,7 +21,7 @@ const FileView = (props) => {
       className={cns}
       onClick={onclickFn}>
       {
-        fileTemplate && fileTemplate({ name: file.name }) ||
+        fileTemplate && fileTemplate(file) ||
         <a>|__{file.name}</a>
       }
     </li>


### PR DESCRIPTION
Lets you use file data in other functions in the template:
e.g
```
  customFile = (props) => {
    return (
      <a  className="file-tree-item" draggable="true"  onDragStart={(e) => this.handleDragStart(e, props)}><span className='file-tree-svg'
        dangerouslySetInnerHTML={{__html: '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" width="24" height="24" viewBox="0 0 24.00 24.00" enable-background="new 0 0 24.00 24.00" xml:space="preserve">' +
        '<path d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M15,18V16H6V18H15M18,14V12H6V14H18Z"></path>' +
        '</svg>'}} />
        { props.name }
      </a>
    )
  }
```

So now we pass props (which in this case is now the entire file) into the `onDragStart` handler